### PR TITLE
Add is excluded-from-valuetype

### DIFF
--- a/lib/ValueType.pm6
+++ b/lib/ValueType.pm6
@@ -1,9 +1,15 @@
 use v6.d;
 
-role ValueType:ver<0.0.3>:auth<cpan:ELIZABETH> {
-    has $!WHICH;
+# no need for :ver or :auth as it is hidden to the outside world
+my role ValueType::Excluded {}
+multi trait_mod:<is> (Attribute \attr, :$excluded-from-valuetype!) is export {
+    attr does ValueType::Excluded
+}
 
-    my @attributes = ::?CLASS.^attributes.grep: *.name ne 'WHICH';
+role ValueType:ver<0.0.3>:auth<cpan:ELIZABETH> {
+    has $!WHICH is excluded-from-valuetype;
+
+    my @attributes = ::?CLASS.^attributes.grep: { $_ !~~ ValueType::Excluded };
 
     multi method WHICH(::?CLASS:D: --> ValueObjAt:D) {
         $!WHICH.defined

--- a/t/02-exclude-attributes.t
+++ b/t/02-exclude-attributes.t
@@ -1,0 +1,33 @@
+use v6.*;
+use Test;
+use ValueType;
+
+plan 2;
+
+class Point does ValueType {
+    has $.x = 0;
+    has $.y = 0;
+
+    # this is only a cache attribute
+    # that is calculated only based on the other ones
+    # so it should not affect .WHICH
+    has $!distance-from-origin is excluded-from-valuetype;
+
+    method distance-from-origin () {
+        $!distance-from-origin //= sqrt $!x² + $!y²
+    }
+
+    # testing method to make sure that the hidden attribute changed
+    method raw-distance-attr () { $!distance-from-origin }
+}
+
+my $a = Point.new( x => 30, y => 40 );
+my $b = Point.new( x => 30, y => 40 );
+
+# change the caching attribute on only one of them
+$a.distance-from-origin;
+
+cmp-ok $a.raw-distance-attr, &[!eqv],  $b.raw-distance-attr, 'double checking that an excluded attribute changed';
+cmp-ok $a, &[===], $b, ｢objects match even though an excluded attribute doesnt match｣;
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
This is useful for attributes that are only used as a cache.

```raku
class Point does ValueType {
    has $.x = 0;
    has $.y = 0;

    has $!distance-from-origin is excluded-from-valuetype;
    method distance-from-origin () {
        $!distance-from-origin //= sqrt $!x² + $!y²
    }
}

my $a = Point.new( x => 30, y => 40 );
my $b = Point.new( x => 30, y => 40 );

say $a.distance-from-origin; # 50
# $!distance-from-origin in $a is now 50
# but is still undefined in $b

say $a === $b; # True
# only $!x and $!y are included in .WHICH
```

---

It also fixes a thinko.  
The `.name` of the `$!WHICH` attribute is `$!WHICH` not `WHICH`

```raku
::?CLASS.^attributes.grep: *.name ne 'WHICH'
```

should have been:

```raku
::?CLASS.^attributes.grep: *.name ne '$!WHICH'
```

I'm not entirely sure why `::?CLASS.^attributes` doesn't include `$!WHICH`.  
It may be that the code is run before the role gets applied.